### PR TITLE
Prevent panic when loading an empty buffer

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -89,6 +89,10 @@ func (r *reader) readRight(nodeNumber uint) uint {
 }
 
 func newReader(buffer []byte) (*reader, error) {
+	if len(buffer) == 0 {
+		return nil, errors.New("buffer is empty")
+	}
+
 	metadataStart := bytes.LastIndex(buffer, metadataStartMarker)
 	metadata, err := readMetadata(buffer[metadataStart+len(metadataStartMarker):])
 	if err != nil {

--- a/reader_test.go
+++ b/reader_test.go
@@ -53,6 +53,13 @@ func TestAnonymousIP(t *testing.T) {
 	}
 }
 
+func TestReaderZeroLength(t *testing.T) {
+	_, err := newReader([]byte{})
+	if err == nil {
+		t.Fatal()
+	}
+}
+
 func TestCity(t *testing.T) {
 	reader, err := NewCityReaderFromFile("testdata/GeoIP2-City-Test.mmdb")
 	if err != nil {


### PR DESCRIPTION
If for some reasons you try to load a truncated to zero file then you end up with a panic.
I'd like to prevent such case. What do you think?