### PR TITLE
Add support for database types other than MaxMind

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -122,3 +122,15 @@ func newReader(buffer []byte) (*reader, error) {
 	}
 	return reader, nil
 }
+
+func isExpectedDatabaseType(databaseType string, expectedTypes ...string) bool {
+	if len(expectedTypes) == 0 {
+		return true
+	}
+	for _, expectedType := range expectedTypes {
+		if databaseType == expectedType {
+			return true
+		}
+	}
+	return false
+}

--- a/reader_anonymous_ip.go
+++ b/reader_anonymous_ip.go
@@ -49,17 +49,21 @@ func (r *AnonymousIPReader) Lookup(ip net.IP) (*AnonymousIP, error) {
 	return result, nil
 }
 
-func NewAnonymousIPReader(buffer []byte) (*AnonymousIPReader, error) {
+func NewAnonymousIPReaderType(buffer []byte, expectedTypes ...string) (*AnonymousIPReader, error) {
 	reader, err := newReader(buffer)
 	if err != nil {
 		return nil, err
 	}
-	if reader.metadata.DatabaseType != "GeoIP2-Anonymous-IP" {
-		return nil, errors.New("wrong MaxMind DB Anonymous-IP type: " + reader.metadata.DatabaseType)
+	if !isExpectedDatabaseType(reader.metadata.DatabaseType, expectedTypes...) {
+		return nil, errors.New("wrong database Anonymous-IP type: " + reader.metadata.DatabaseType)
 	}
 	return &AnonymousIPReader{
 		reader: reader,
 	}, nil
+}
+
+func NewAnonymousIPReader(buffer []byte) (*AnonymousIPReader, error) {
+	return NewAnonymousIPReaderType(buffer, "GeoIP2-Anonymous-IP")
 }
 
 func NewAnonymousIPReaderFromFile(filename string) (*AnonymousIPReader, error) {

--- a/reader_asn.go
+++ b/reader_asn.go
@@ -49,17 +49,21 @@ func (r *ASNReader) Lookup(ip net.IP) (*ASN, error) {
 	return result, nil
 }
 
-func NewASNReader(buffer []byte) (*ASNReader, error) {
+func NewASNReaderType(buffer []byte, expectedTypes ...string) (*ASNReader, error) {
 	reader, err := newReader(buffer)
 	if err != nil {
 		return nil, err
 	}
-	if reader.metadata.DatabaseType != "GeoLite2-ASN" {
-		return nil, errors.New("wrong MaxMind DB ASN type: " + reader.metadata.DatabaseType)
+	if !isExpectedDatabaseType(reader.metadata.DatabaseType, expectedTypes...) {
+		return nil, errors.New("wrong database ASN type: " + reader.metadata.DatabaseType)
 	}
 	return &ASNReader{
 		reader: reader,
 	}, nil
+}
+
+func NewASNReader(buffer []byte) (*ASNReader, error) {
+	return NewASNReaderType(buffer, "GeoLite2-ASN")
 }
 
 func NewASNReaderFromFile(filename string) (*ASNReader, error) {

--- a/reader_city.go
+++ b/reader_city.go
@@ -83,19 +83,21 @@ func (r *CityReader) Lookup(ip net.IP) (*CityResult, error) {
 	return result, nil
 }
 
-func NewCityReader(buffer []byte) (*CityReader, error) {
+func NewCityReaderType(buffer []byte, expectedTypes ...string) (*CityReader, error) {
 	reader, err := newReader(buffer)
 	if err != nil {
 		return nil, err
 	}
-	if reader.metadata.DatabaseType != "GeoIP2-City" &&
-		reader.metadata.DatabaseType != "GeoLite2-City" &&
-		reader.metadata.DatabaseType != "GeoIP2-Enterprise" {
-		return nil, errors.New("wrong MaxMind DB City type: " + reader.metadata.DatabaseType)
+	if !isExpectedDatabaseType(reader.metadata.DatabaseType, expectedTypes...) {
+		return nil, errors.New("wrong database City type: " + reader.metadata.DatabaseType)
 	}
 	return &CityReader{
 		reader: reader,
 	}, nil
+}
+
+func NewCityReader(buffer []byte) (*CityReader, error) {
+	return NewCityReaderType(buffer, "GeoIP2-City", "GeoLite2-City", "GeoIP2-Enterprise")
 }
 
 func NewCityReaderFromFile(filename string) (*CityReader, error) {

--- a/reader_connection_type.go
+++ b/reader_connection_type.go
@@ -49,17 +49,21 @@ func (r *ConnectionTypeReader) Lookup(ip net.IP) (string, error) {
 	return result.ConnectionType, nil
 }
 
-func NewConnectionTypeReader(buffer []byte) (*ConnectionTypeReader, error) {
+func NewConnectionTypeReaderType(buffer []byte, expectedTypes ...string) (*ConnectionTypeReader, error) {
 	reader, err := newReader(buffer)
 	if err != nil {
 		return nil, err
 	}
-	if reader.metadata.DatabaseType != "GeoIP2-Connection-Type" {
-		return nil, errors.New("wrong MaxMind DB Connection-Type type: " + reader.metadata.DatabaseType)
+	if !isExpectedDatabaseType(reader.metadata.DatabaseType, expectedTypes...) {
+		return nil, errors.New("wrong database Connection-Type type: " + reader.metadata.DatabaseType)
 	}
 	return &ConnectionTypeReader{
 		reader: reader,
 	}, nil
+}
+
+func NewConnectionTypeReader(buffer []byte) (*ConnectionTypeReader, error) {
+	return NewConnectionTypeReaderType(buffer, "GeoIP2-Connection-Type")
 }
 
 func NewConnectionTypeReaderFromFile(filename string) (*ConnectionTypeReader, error) {

--- a/reader_country.go
+++ b/reader_country.go
@@ -63,18 +63,21 @@ func (r *CountryReader) Lookup(ip net.IP) (*CountryResult, error) {
 	return result, nil
 }
 
-func NewCountryReader(buffer []byte) (*CountryReader, error) {
+func NewCountryReaderType(buffer []byte, expectedTypes ...string) (*CountryReader, error) {
 	reader, err := newReader(buffer)
 	if err != nil {
 		return nil, err
 	}
-	if reader.metadata.DatabaseType != "GeoIP2-Country" &&
-		reader.metadata.DatabaseType != "GeoLite2-Country" {
-		return nil, errors.New("wrong MaxMind DB Country type: " + reader.metadata.DatabaseType)
+	if !isExpectedDatabaseType(reader.metadata.DatabaseType, expectedTypes...) {
+		return nil, errors.New("wrong database Country type: " + reader.metadata.DatabaseType)
 	}
 	return &CountryReader{
 		reader: reader,
 	}, nil
+}
+
+func NewCountryReader(buffer []byte) (*CountryReader, error) {
+	return NewCountryReaderType(buffer, "GeoIP2-Country", "GeoLite2-Country", "Geoacumen-Country")
 }
 
 func NewCountryReaderFromFile(filename string) (*CountryReader, error) {

--- a/reader_domain.go
+++ b/reader_domain.go
@@ -49,17 +49,21 @@ func (r *DomainReader) Lookup(ip net.IP) (string, error) {
 	return result.Domain, nil
 }
 
-func NewDomainReader(buffer []byte) (*DomainReader, error) {
+func NewDomainReaderType(buffer []byte, expectedTypes ...string) (*DomainReader, error) {
 	reader, err := newReader(buffer)
 	if err != nil {
 		return nil, err
 	}
-	if reader.metadata.DatabaseType != "GeoIP2-Domain" {
-		return nil, errors.New("wrong MaxMind DB Domain type: " + reader.metadata.DatabaseType)
+	if !isExpectedDatabaseType(reader.metadata.DatabaseType, expectedTypes...) {
+		return nil, errors.New("wrong database Domain type: " + reader.metadata.DatabaseType)
 	}
 	return &DomainReader{
 		reader: reader,
 	}, nil
+}
+
+func NewDomainReader(buffer []byte) (*DomainReader, error) {
+	return NewDomainReaderType(buffer, "GeoIP2-Domain")
 }
 
 func NewDomainReaderFromFile(filename string) (*DomainReader, error) {

--- a/reader_isp.go
+++ b/reader_isp.go
@@ -49,17 +49,21 @@ func (r *ISPReader) Lookup(ip net.IP) (*ISP, error) {
 	return result, nil
 }
 
-func NewISPReader(buffer []byte) (*ISPReader, error) {
+func NewISPReaderType(buffer []byte, expectedTypes ...string) (*ISPReader, error) {
 	reader, err := newReader(buffer)
 	if err != nil {
 		return nil, err
 	}
-	if reader.metadata.DatabaseType != "GeoIP2-ISP" {
-		return nil, errors.New("wrong MaxMind DB ISP type: " + reader.metadata.DatabaseType)
+	if !isExpectedDatabaseType(reader.metadata.DatabaseType, expectedTypes...) {
+		return nil, errors.New("wrong database ISP type: " + reader.metadata.DatabaseType)
 	}
 	return &ISPReader{
 		reader: reader,
 	}, nil
+}
+
+func NewISPReader(buffer []byte) (*ISPReader, error) {
+	return NewISPReaderType(buffer, "GeoIP2-ISP")
 }
 
 func NewISPReaderFromFile(filename string) (*ISPReader, error) {


### PR DESCRIPTION
There are now a number of alternative providers of MMDB databases (including the free [Geoacumen](https://github.com/geoacumen/geoacumen-country) database generated from ASN data), but they are unusable with the geoip2 library because it explicitly checks for a MaxMind-specific `reader.metadata.DatabaseType`.

This pull request maintains the current behavior while adding the option to specify a custom database type when needed by calling `NewXxxReaderType()` instead of `NewXxxReader()`. It also accepts `Geoacumen-Country` as a valid database type for `NewCountryReader()` by default.
