### PR TITLE
Update tests to handle current version of .mmdb files and use of submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "testdata/maxmind"]
+	path = testdata/maxmind
+	url = https://github.com/maxmind/MaxMind-DB

--- a/README.md
+++ b/README.md
@@ -89,6 +89,23 @@ connection_type_parallel-24    34284831    32.1 ns/op     32 B/op     2 allocs/o
 ### Domain
 - GeoIP2-Domain
 
+## MMDB files for tests
+
+MMDB files for tests are organised in their respective directories based on the source within the `testdata` repository root directory.
+
+### MaxMind
+
+These are obtained using a submodule into a `testdata/maxmind` directory.
+
+```
+git submodule init
+git submodule update
+```
+
+### DB-IP
+
+You must obtain these files manually and place them into the `testdata/dbip` directory.
+
 ## License
 
 [MIT License](LICENSE).

--- a/geoip2_test.go
+++ b/geoip2_test.go
@@ -6,9 +6,9 @@ import (
 )
 
 func TestReader(t *testing.T) {
-	ip := net.ParseIP("81.2.69.142")
+	ip := net.ParseIP("81.2.69.160")
 
-	countryReader, err := NewCountryReaderFromFile("testdata/GeoIP2-Country.mmdb")
+	countryReader, err := NewCountryReaderFromFile("testdata/maxmind/test-data/GeoIP2-Country-Test.mmdb")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -16,7 +16,7 @@ func TestReader(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	countryLiteReader, err := NewCountryReaderFromFile("testdata/GeoLite2-Country.mmdb")
+	countryLiteReader, err := NewCountryReaderFromFile("testdata/maxmind/test-data/GeoLite2-Country-Test.mmdb")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -25,7 +25,7 @@ func TestReader(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cityReader, err := NewCityReaderFromFile("testdata/GeoIP2-City.mmdb")
+	cityReader, err := NewCityReaderFromFile("testdata/maxmind/test-data/GeoIP2-City-Test.mmdb")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -33,7 +33,7 @@ func TestReader(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	cityLiteReader, err := NewCityReaderFromFile("testdata/GeoLite2-City.mmdb")
+	cityLiteReader, err := NewCityReaderFromFile("testdata/maxmind/test-data/GeoLite2-City-Test.mmdb")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -42,7 +42,7 @@ func TestReader(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ispReader, err := NewISPReaderFromFile("testdata/GeoIP2-ISP.mmdb")
+	ispReader, err := NewISPReaderFromFile("testdata/maxmind/test-data/GeoIP2-ISP-Test.mmdb")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -51,7 +51,8 @@ func TestReader(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	connectionTypeReader, err := NewConnectionTypeReaderFromFile("testdata/GeoIP2-Connection-Type.mmdb")
+	ip = net.ParseIP("2.125.160.216")
+	connectionTypeReader, err := NewConnectionTypeReaderFromFile("testdata/maxmind/test-data/GeoIP2-Connection-Type-Test.mmdb")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -60,7 +61,8 @@ func TestReader(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	asnReader, err := NewASNReaderFromFile("testdata/GeoLite2-ASN.mmdb")
+	ip = net.ParseIP("81.128.69.160")
+	asnReader, err := NewASNReaderFromFile("testdata/maxmind/test-data/GeoLite2-ASN-Test.mmdb")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,7 +77,7 @@ func BenchmarkGeoIP2(b *testing.B) {
 	b.ReportAllocs()
 
 	b.Run("country", func(b *testing.B) {
-		reader, err := NewCountryReaderFromFile("testdata/GeoIP2-Country.mmdb")
+		reader, err := NewCountryReaderFromFile("testdata/maxmind/test-data/GeoIP2-Country-Test.mmdb")
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -94,7 +96,7 @@ func BenchmarkGeoIP2(b *testing.B) {
 	})
 
 	b.Run("city", func(b *testing.B) {
-		reader, err := NewCityReaderFromFile("testdata/GeoIP2-City.mmdb")
+		reader, err := NewCityReaderFromFile("testdata/maxmind/test-data/GeoIP2-City-Test.mmdb")
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -113,7 +115,7 @@ func BenchmarkGeoIP2(b *testing.B) {
 	})
 
 	b.Run("isp", func(b *testing.B) {
-		reader, err := NewISPReaderFromFile("testdata/GeoIP2-ISP.mmdb")
+		reader, err := NewISPReaderFromFile("testdata/maxmind/test-data/GeoIP2-ISP-Test.mmdb")
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -132,7 +134,7 @@ func BenchmarkGeoIP2(b *testing.B) {
 	})
 
 	b.Run("connection_type", func(b *testing.B) {
-		reader, err := NewConnectionTypeReaderFromFile("testdata/GeoIP2-Connection-Type.mmdb")
+		reader, err := NewConnectionTypeReaderFromFile("testdata/maxmind/test-data/GeoIP2-Connection-Type-Test.mmdb")
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -151,7 +153,7 @@ func BenchmarkGeoIP2(b *testing.B) {
 	})
 
 	b.Run("asn", func(b *testing.B) {
-		reader, err := NewASNReaderFromFile("testdata/GeoLite2-ASN.mmdb")
+		reader, err := NewASNReaderFromFile("testdata/maxmind/test-data/GeoLite2-ASN-Test.mmdb")
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/reader_test.go
+++ b/reader_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestAnonymousIP(t *testing.T) {
-	reader, err := NewAnonymousIPReaderFromFile("testdata/GeoIP2-Anonymous-IP-Test.mmdb")
+	reader, err := NewAnonymousIPReaderFromFile("testdata/maxmind/test-data/GeoIP2-Anonymous-IP-Test.mmdb")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -63,7 +63,7 @@ func TestReaderZeroLength(t *testing.T) {
 }
 
 func TestCity(t *testing.T) {
-	reader, err := NewCityReaderFromFile("testdata/GeoIP2-City-Test.mmdb")
+	reader, err := NewCityReaderFromFile("testdata/maxmind/test-data/GeoIP2-City-Test.mmdb")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -133,7 +133,7 @@ func TestCity(t *testing.T) {
 }
 
 func TestConnectionType(t *testing.T) {
-	reader, err := NewConnectionTypeReaderFromFile("testdata/GeoIP2-Connection-Type-Test.mmdb")
+	reader, err := NewConnectionTypeReaderFromFile("testdata/maxmind/test-data/GeoIP2-Connection-Type-Test.mmdb")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -142,7 +142,7 @@ func TestConnectionType(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if record != "Dialup" {
+	if record != "Cable/DSL" {
 		t.Fatal()
 	}
 
@@ -150,13 +150,13 @@ func TestConnectionType(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if record != "Cable/DSL" {
+	if record != "Cellular" {
 		t.Fatal()
 	}
 }
 
 func TestCountry(t *testing.T) {
-	reader, err := NewCountryReaderFromFile("testdata/GeoIP2-Country-Test.mmdb")
+	reader, err := NewCountryReaderFromFile("testdata/maxmind/test-data/GeoIP2-Country-Test.mmdb")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -240,7 +240,7 @@ func TestCountry(t *testing.T) {
 }
 
 func TestDomain(t *testing.T) {
-	reader, err := NewDomainReaderFromFile("testdata/GeoIP2-Domain-Test.mmdb")
+	reader, err := NewDomainReaderFromFile("testdata/maxmind/test-data/GeoIP2-Domain-Test.mmdb")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -263,7 +263,7 @@ func TestDomain(t *testing.T) {
 }
 
 func TestEnterprise(t *testing.T) {
-	reader, err := NewEnterpriseReaderFromFile("testdata/GeoIP2-Enterprise-Test.mmdb")
+	reader, err := NewEnterpriseReaderFromFile("testdata/maxmind/test-data/GeoIP2-Enterprise-Test.mmdb")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -340,7 +340,7 @@ func TestEnterprise(t *testing.T) {
 }
 
 func TestISP(t *testing.T) {
-	reader, err := NewISPReaderFromFile("testdata/GeoIP2-ISP-Test.mmdb")
+	reader, err := NewISPReaderFromFile("testdata/maxmind/test-data/GeoIP2-ISP-Test.mmdb")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -381,7 +381,7 @@ func TestISP(t *testing.T) {
 }
 
 func TestASN(t *testing.T) {
-	reader, err := NewASNReaderFromFile("testdata/GeoLite2-ASN-Test.mmdb")
+	reader, err := NewASNReaderFromFile("testdata/maxmind/test-data/GeoLite2-ASN-Test.mmdb")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -410,7 +410,7 @@ func TestASN(t *testing.T) {
 }
 
 func TestDBIPCity(t *testing.T) {
-	reader, err := NewCityReaderFromFile("testdata/dbip-city-lite.mmdb")
+	reader, err := NewCityReaderFromFile("testdata/dbip/dbip-city-lite.mmdb")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -421,13 +421,13 @@ func TestDBIPCity(t *testing.T) {
 	if record.City.GeoNameID != 0 {
 		t.Fatal()
 	}
-	if record.City.Names["en"] != "Boston" {
+	if record.City.Names["en"] != "Medfield" {
 		t.Fatal()
 	}
-	if record.Location.Latitude != 42.3601 {
+	if record.Location.Latitude != 42.1876 {
 		t.Fatal()
 	}
-	if record.Location.Longitude != -71.0589 {
+	if record.Location.Longitude != -71.3065 {
 		t.Fatal()
 	}
 	if len(record.Subdivisions) != 1 {
@@ -439,7 +439,7 @@ func TestDBIPCity(t *testing.T) {
 }
 
 func TestDBIPCountry(t *testing.T) {
-	reader, err := NewCountryReaderFromFile("testdata/dbip-country-lite.mmdb")
+	reader, err := NewCountryReaderFromFile("testdata/dbip/dbip-country-lite.mmdb")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -473,7 +473,7 @@ func TestDBIPCountry(t *testing.T) {
 }
 
 func TestDBIPASN(t *testing.T) {
-	reader, err := NewASNReaderFromFile("testdata/dbip-asn-lite.mmdb")
+	reader, err := NewASNReaderFromFile("testdata/dbip/dbip-asn-lite.mmdb")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
While preparing to add a new feature I updated tests in the following way:

* move test files to separate directories for different sources (MaxMind, DB-IP)
* get MaxMind test .mmdb files from their github repo using submodule
* update paths for .mmdb files for tests
* update tests to match the current (2025-01) version of MaxMind .mmdb test files
* update README by adding a section about obtaining test .mmdb files

Let me know what you think.